### PR TITLE
Add stage filter for central content

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -6,6 +6,7 @@ const GRADES = [
   {key:'TILLATET',label:'Tillåtet',icon:'✅'},
   {key:'OBLIGATORISKT',label:'Obligatoriskt',icon:'📌'}
 ];
+const CC_STAGE_LABELS = { '1-3':'lågstadiet', '4-6':'mellanstadiet', '7-9':'högstadiet' };
 
 // ---- State ----
 let subjectsIndex = [];
@@ -30,6 +31,7 @@ async function init(){
   $('#btnExportJSON').addEventListener('click', exportJSON);
   $('#btnExportMD').addEventListener('click', exportMD);
   $('#btnAdd').addEventListener('click', addAssignment);
+  $('#ccStageFilter').addEventListener('change', renderSubject);
 
   // ladda ämneslista lokalt
   await loadIndex();
@@ -157,8 +159,17 @@ function renderSubject(){
   $('#subjectPurpose').innerHTML = currentSubject?.purpose
     ? `<div class="block"><h4>Syfte</h4><div>${currentSubject.purpose}</div></div>` : '';
 
+  const stageFilter = $('#ccStageFilter')?.value || '';
+  const ccTitle = stageFilter && CC_STAGE_LABELS[stageFilter]
+    ? `Centralt innehåll för ${CC_STAGE_LABELS[stageFilter]}`
+    : 'Centralt innehåll';
+  $('#ccTitle').textContent = ccTitle;
+
   const cc = $('#ccList'); cc.innerHTML = '';
+  const knownStageIds = Object.keys(CC_STAGE_LABELS);
   (currentSubject?.centralContent || []).forEach(c=>{
+    const isStage = knownStageIds.includes(c.id);
+    if(stageFilter && isStage && c.id !== stageFilter) return;
     const li = document.createElement('li');
     li.innerHTML = `<span class="badge">${c.id}</span> ${c.text}`;
     cc.appendChild(li);

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,17 @@
         <h3 id="subjectTitle">Ämnesöversikt</h3>
         <div id="subjectPurpose"></div>
         <div class="block">
-          <h4>Centralt innehåll</h4>
+          <h4 id="ccTitle">Centralt innehåll</h4>
+          <div class="row tiny">
+            <label>Stadie:
+              <select id="ccStageFilter">
+                <option value="">Alla</option>
+                <option value="1-3">Lågstadiet (1–3)</option>
+                <option value="4-6">Mellanstadiet (4–6)</option>
+                <option value="7-9">Högstadiet (7–9)</option>
+              </select>
+            </label>
+          </div>
           <ul id="ccList" class="list"></ul>
         </div>
         <div class="block">


### PR DESCRIPTION
## Summary
- allow teachers to filter central content by stadie (1-3, 4-6, 7-9)
- update rendering logic to show heading for selected stage

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68b4389a6b2083288fc53b73195e091e