### PR TITLE
Enable stage sorting in overview and assignments

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,6 +59,13 @@
                 <option value="7-9">Högstadiet (7–9)</option>
               </select>
             </label>
+            <label>Sortera:
+              <select id="ccSort">
+                <option value="">Ursprunglig</option>
+                <option value="asc">F–3 → 7–9</option>
+                <option value="desc">7–9 → F–3</option>
+              </select>
+            </label>
           </div>
           <ul id="ccList" class="list"></ul>
         </div>
@@ -71,7 +78,17 @@
       <div class="card">
         <div class="row between">
           <h3>Bedömningsmoment (stadie-matris)</h3>
-          <button id="btnAdd">+ Nytt moment</button>
+          <div class="row">
+            <label class="tiny">Sortera:
+              <select id="assignStageSort">
+                <option value="">Ingen</option>
+                <option value="F-3">F–3</option>
+                <option value="4-6">4–6</option>
+                <option value="7-9">7–9</option>
+              </select>
+            </label>
+            <button id="btnAdd">+ Nytt moment</button>
+          </div>
         </div>
         <div id="assignments"></div>
       </div>


### PR DESCRIPTION
## Summary
- add dropdowns to sort central content and assessment items by school stage
- implement stage-aware sorting logic for content lists, assignment tables, and preview output

## Testing
- `node --check docs/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b47af51e0c8328944eea2aa01370f7