### PR TITLE
Allow single-stage selection for assessment moments

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
 
       <div class="card">
         <div class="row between">
-          <h3>Bedömningsmoment (stadie-matris)</h3>
+          <h3>Bedömningsmoment</h3>
           <div class="row">
             <label class="tiny">Sortera:
               <select id="assignStageSort">


### PR DESCRIPTION
## Summary
- Allow each assessment moment to track only one stage and grade
- Simplify assignment rendering with a stage selector and grade badges
- Adjust preview generation and heading to reflect single-stage moments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b47cf7d2548328a267e2494758a7b7