### PR TITLE
Improve subject overview sorting and add DOCX/PDF export

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,8 @@
         <div class="row">
           <button id="btnExportJSON">Exportera JSON</button>
           <button id="btnExportMD">Exportera instruktioner (MD)</button>
+          <button id="btnExportDOCX">Exportera DOCX</button>
+          <button id="btnExportPDF">Exportera PDF</button>
         </div>
       </div>
     </section>
@@ -134,6 +136,8 @@
     </footer>
   </div>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html-docx-js/0.5.1/html-docx.min.js"></script>
   <script src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hide assignments from other stages when sorting to make subject overview clearer
- Add DOCX and PDF export options with jsPDF and html-docx support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b48000ae6083288523d9a90d06446f