### PR TITLE
Handle numeric year values in knowledge requirement stage filter

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -231,9 +231,9 @@ function normalizeKR(list){
 
   const toBand = (y) => {
     const s = String(y||'').toLowerCase();
-    if (/1\s*[-–]\s*3|åk\s*3|årskurs\s*3/.test(s)) return '1-3';
-    if (/4\s*[-–]\s*6|åk\s*6|årskurs\s*6/.test(s)) return '4-6';
-    if (/7\s*[-–]\s*9|åk\s*9|årskurs\s*9/.test(s)) return '7-9';
+    if (/1\s*[-–]\s*3|åk\s*3|årskurs\s*3|^3$/.test(s)) return '1-3';
+    if (/4\s*[-–]\s*6|åk\s*6|årskurs\s*6|^6$/.test(s)) return '4-6';
+    if (/7\s*[-–]\s*9|åk\s*9|årskurs\s*9|^9$/.test(s)) return '7-9';
     // API kan ibland redan ge bandet direkt
     if (/^1-3$|^4-6$|^7-9$/.test(s)) return s;
     return '';


### PR DESCRIPTION
## Summary
- ensure knowledge requirements are correctly grouped by stage when their year is given as a number

## Testing
- `node --check docs/app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b5640b393083289fb31236e3b6eac2