### PR TITLE
Handle subject codes in AIAS mapping

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -195,10 +195,17 @@ const AIAS_EN = {
 // ---------------------------------------------------------
 function getAIAS(subjectIdOrName) {
   const s = String(subjectIdOrName || "").toUpperCase();
-  if (s.includes("MATEMATIK")) return AIAS_MA;
-  if (s.includes("ENGELSKA")) return AIAS_EN;
-  if (s.includes("SVENSKA")) return AIAS_SV;
-  // Lägg fler här (BIOLOGI → AIAS_BIO, HISTORIA → AIAS_HIS, etc.)
+
+  // Matcha både namn och ämneskoder
+  if (s.includes("MATEMATIK") || s.startsWith("GRGRMAT")) return AIAS_MA;
+  if (s.includes("ENGELSKA") || s.startsWith("GRGRENG")) return AIAS_EN;
+  if (
+    s.includes("SVENSKA") ||
+    s.startsWith("GRGRSVE") || // Svenska
+    s.startsWith("GRGRSVA")    // Svenska som andraspråk
+  )
+    return AIAS_SV;
+
   return AIAS; // fallback
 }
 


### PR DESCRIPTION
## Summary
- match both subject names and IDs to select the appropriate AIAS list

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5a761c0bc832888db5bf6da691744