### PR TITLE
Add central content toggle

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -230,6 +230,7 @@ function saveLocal() {
       subjectId: $("#subjectSelect")?.value,
       stage: $("#stageSelect")?.value,
       aias: $("#toggleAias")?.checked,
+      markCC: $("#toggleCc")?.checked,
     };
     localStorage.setItem(SAVE_KEY, JSON.stringify(s));
   } catch {}
@@ -618,7 +619,8 @@ function renderText() {
   }
   const stage = $("#stageSelect")?.value || "4-6";
   const aias = !!$("#toggleAias")?.checked;
-  const html = sanitizeHtml(buildHtml(currentSubject, stage, { aias, markCC: false }));
+  const markCC = !!$("#toggleCc")?.checked;
+  const html = sanitizeHtml(buildHtml(currentSubject, stage, { aias, markCC }));
   const out = $("#mdOut");
   if (out) out.innerHTML = html;
 }
@@ -706,6 +708,13 @@ function renderText() {
       saveLocal();
     });
   }
+  const ccTgl = $("#toggleCc");
+  if (ccTgl) {
+    ccTgl.addEventListener("change", () => {
+      renderText();
+      saveLocal();
+    });
+  }
 
   // Ladda ämnen
   await loadSubjects();
@@ -721,6 +730,7 @@ function renderText() {
   }
   if (stageSel && prev.stage) stageSel.value = prev.stage;
   if (aiasTgl && typeof prev.aias === "boolean") aiasTgl.checked = prev.aias;
+  if (ccTgl && typeof prev.markCC === "boolean") ccTgl.checked = prev.markCC;
 
   // Hämta kursplan
   if (subjSel?.value) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
         </select>
       </div>
       <label class="row"><input id="toggleAias" type="checkbox" checked> Visa AI-markeringar (AIAS)</label>
+      <label class="row"><input id="toggleCc" type="checkbox"> Markera centralt innehåll</label>
       <span id="status" class="muted"></span>
     </div>
     <div class="row" style="margin-top:8px">


### PR DESCRIPTION
## Summary
- add 'Markera centralt innehåll' checkbox to toggle central content AIAS highlighting
- remember central content toggle in local storage and apply on render

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5b2c707908328b01980d2d51fd405