### PR TITLE
Add subject list source indicator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
       <div class="row">
         <label>Ämne</label>
         <select id="subjectSelect"></select>
+        <span id="subjectSource" class="tiny muted"></span>
       </div>
       <div class="row">
         <label>Stadie</label>

--- a/docs/src/api.js
+++ b/docs/src/api.js
@@ -75,6 +75,7 @@ function normalizeKR(list) {
 
 export async function loadSubjects(setStatus) {
   setStatus("Hämtar ämnen…");
+  let listType = "Standardlista";
   try {
     const { res, viaProxy } = await fetchApi(`${API_BASE}/subjects`);
     const raw = await res.json();
@@ -98,10 +99,12 @@ export async function loadSubjects(setStatus) {
       throw new Error("Inga giltiga poster (saknar id/name)");
 
     setStatus(viaProxy ? "Ämnen via API (proxy)" : "Ämnen via API");
+    listType = "Standardlista";
   } catch (e) {
     console.warn("loadSubjects fallback:", e);
     setStatus("API misslyckades – visar lokal ämneslista");
     subjectsIndex = getLocalSubjectsFallback();
+    listType = "AIAS ämneslista";
   }
 
   const sel = document.querySelector("#subjectSelect");
@@ -112,6 +115,8 @@ export async function loadSubjects(setStatus) {
   if (!sel.value && subjectsIndex.length) {
     sel.value = subjectsIndex[0].id;
   }
+  const srcEl = document.querySelector("#subjectSource");
+  if (srcEl) srcEl.textContent = listType;
 }
 
 export async function setSubject(subjectId, setStatus) {


### PR DESCRIPTION
## Summary
- Show which subject list is loaded by displaying "Standardlista" or "AIAS ämneslista" next to subject selection
- Set indicator automatically based on API availability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b6ade23ca483289f08086a1cda555b