### PR TITLE
Show selected lexicon for each subject

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,7 @@
         <label>Ämne</label>
         <select id="subjectSelect"></select>
         <span id="subjectSource" class="tiny muted"></span>
+        <span id="lexiconLabel" class="tiny muted"></span>
       </div>
       <div class="row">
         <label>Stadie</label>

--- a/docs/src/render.js
+++ b/docs/src/render.js
@@ -239,12 +239,18 @@ export function renderText() {
   if (!currentSubject) {
     const out = document.querySelector("#mdOut");
     if (out) out.innerHTML = "";
+    const labelEl = document.querySelector("#lexiconLabel");
+    if (labelEl) labelEl.textContent = "";
     return;
   }
   const stage = document.querySelector("#stageSelect")?.value || "4-6";
   const aias = !!document.querySelector("#toggleAias")?.checked;
   const markCC = !!document.querySelector("#toggleCc")?.checked;
+  const activeAIAS = getAIAS(currentSubject);
   const html = sanitizeHtml(buildHtml(currentSubject, stage, { aias, markCC }));
   const out = document.querySelector("#mdOut");
   if (out) out.innerHTML = html;
+  const labelEl = document.querySelector("#lexiconLabel");
+  if (labelEl)
+    labelEl.textContent = `Lexikon: ${activeAIAS.lexiconLabel}`;
 }


### PR DESCRIPTION
## Summary
- Display which lexicon is active next to the subject selector
- Update rendering logic to populate header lexicon label

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68b6b5e19b70832888a4a56d52ef9d2a