### PR TITLE
Replace 'Tillåtet' label with 'Introducera'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
     </div>
     <div class="row" style="margin-top:8px">
       <span class="badge">⛔ Förbjudet</span>
-      <span class="badge">✅ Tillåtet</span>
+      <span class="badge">🌱 Introducera</span>
       <span class="badge">📌 Förväntat</span>
       <span class="badge">🔗 Integrerat</span>
     </div>
@@ -37,7 +37,7 @@
       <h3>AI-stöd (pedagogens kompass)</h3>
       <ul class="ai-help">
         <li>⛔ <strong>Förbjudet</strong>: Fokus på baskunskaper och ämnesspråk. <em>Introducera inte AI som verktyg ännu.</em></li>
-        <li>✅ <strong>Tillåtet</strong>: Introducera AI i små steg för <em>struktur, disposition och exempel</em>. Undvik färdiga svar – kräv <em>omformulering med egna ord</em>.</li>
+        <li>🌱 <strong>Introducera</strong>: Introducera AI i små steg för <em>struktur, disposition och exempel</em>. Undvik färdiga svar – kräv <em>omformulering med egna ord</em>.</li>
         <li>📌 <strong>Förväntat</strong>: Använd AI som <em>sparringpartner</em> för att få <em>perspektiv, argument och jämförelser</em>. Eleven ska <em>välja, motivera och dra slutsatser</em>.</li>
         <li>🔗 <strong>Integrerat</strong>: Använd AI för <em>källkritik och fördjupning</em>: jämför källor, be om motargument, kontrollera bias och <em>dokumentera granskningssteg</em>.</li>
       </ul>
@@ -75,7 +75,7 @@
       </p>
       <ul>
         <li>⛔ <em>Förbjudet</em>: baskunskaper, AI bör inte introduceras.</li>
-        <li>✅ <em>Tillåtet</em>: fungerande kunskaper, AI kan stödja struktur och exempel.</li>
+        <li>🌱 <em>Introducera</em>: fungerande kunskaper, AI kan stödja struktur och exempel.</li>
         <li>📌 <em>Förväntat</em>: analysnivå, AI kan användas för perspektiv och resonemang.</li>
         <li>🔗 <em>Integrerat</em>: avancerad nivå, AI kan bli en kritisk partner och användas för nyansering.</li>
       </ul>

--- a/docs/index3.html
+++ b/docs/index3.html
@@ -117,8 +117,8 @@
           </div>
         </div>
         <div class="lvl">
-          <div class="icon">✅</div>
-          <div><b>Tillåtet</b> – AI som hjälpmedel; eleven visar förståelse. <i>Logg krävs.</i>
+          <div class="icon">🌱</div>
+          <div><b>Introducera</b> – AI som hjälpmedel; eleven visar förståelse. <i>Logg krävs.</i>
             <div class="tiny muted">Exempelord (Skolverket): <em>utvecklade</em>, <em>resonera utförligt</em>, <em>jämföra</em>, <em>bearbeta</em></div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace '✅ Tillåtet' with '🌱 Introducera' across documentation badges and descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b6bf4c2b008328adf2dd1ba5e2e06f