### PR TITLE
Rename Tillåtet category to Introducera

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,7 @@
 
   <footer>
     <p class="muted">
-      ⚖️ Disclaimer: Symbolerna (⛔/✅/📌/🔗) är pedagogiska förslag baserade på kursplanens formuleringar (AIAS).
+      ⚖️ Disclaimer: Symbolerna (⛔/🌱/📌/🔗) är pedagogiska förslag baserade på kursplanens formuleringar (AIAS).
       De ersätter inte lärarens professionella tolkning. Verktyget behandlar inga personuppgifter och sparar endast lokala
       inställningar i webbläsaren. Användning av AI i undervisningen ska ske enligt skolans policy och gällande lagstiftning.
     </p>

--- a/docs/lexicons/aias-base.js
+++ b/docs/lexicons/aias-base.js
@@ -11,8 +11,8 @@ export const AIAS = {
       "ljudning","ljudningsstrategi"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "utvecklade resonemang","relativt välgrundade","förhållandevis komplexa samband",
       "beskriva","jämföra","resonera","förklara",

--- a/docs/lexicons/aias-bild.js
+++ b/docs/lexicons/aias-bild.js
@@ -13,8 +13,8 @@ export const AIAS_BILD = {
       "något exempel", "viss säkerhet"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "beskriva", "förklara", "jämföra",
       "använda bildbegrepp", "använder bildbegrepp",

--- a/docs/lexicons/aias-en.js
+++ b/docs/lexicons/aias-en.js
@@ -7,8 +7,8 @@ export const AIAS_EN = {
       "i någon mån underlättar","i någon mån","översiktligt","grundläggande"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "huvudsakligt innehåll","relativt tydligt och sammanhängande",
       "relativt tydligt","relativt sammanhängande",

--- a/docs/lexicons/aias-idr.js
+++ b/docs/lexicons/aias-idr.js
@@ -10,8 +10,8 @@ export const AIAS_IDR = {
       "något exempel", "viss säkerhet"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "genomföra", "deltar", "delta",
       "träna", "övning", "rörelse",

--- a/docs/lexicons/aias-ma.js
+++ b/docs/lexicons/aias-ma.js
@@ -7,8 +7,8 @@ export const AIAS_MA = {
       "tillfredsställande säkerhet","grundläggande kunskaper"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "ändamålsenliga metoder","goda kunskaper","god säkerhet",
       "relativt komplexa problem","relativt väl underbyggda argument","relativt välgrundade"

--- a/docs/lexicons/aias-mus.js
+++ b/docs/lexicons/aias-mus.js
@@ -17,8 +17,8 @@ export const AIAS_MUS = {
       "något exempel"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "beskriva", "resonera", "jämföra", "förklara",
       "använda musikbegrepp", "använder musikbegrepp",

--- a/docs/lexicons/aias-slj.js
+++ b/docs/lexicons/aias-slj.js
@@ -11,8 +11,8 @@ export const AIAS_SLJ = {
       "något exempel", "i viss mån", "viss säkerhet"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "beskriva", "förklara", "jämföra", "resonera",
       "välja material", "välja redskap", "välja metod",

--- a/docs/lexicons/aias-sv.js
+++ b/docs/lexicons/aias-sv.js
@@ -11,8 +11,8 @@ export const AIAS_SV = {
       "stor bokstav","punkt","frågetecken"
     ]
   },
-  TILLATET: {
-    icon: "✅",
+  INTRODUCERA: {
+    icon: "🌱",
     words: [
       "utvecklade resonemang","tydligt framträdande innehåll","huvudsakligt innehåll",
       "detaljer","väsentliga","relativt tydligt","relativt sammanhängande",

--- a/docs/src/render.js
+++ b/docs/src/render.js
@@ -9,7 +9,7 @@ import { AIAS_SLJ } from "../lexicons/aias-slj.js";
 import { AIAS_BILD } from "../lexicons/aias-bild.js";
 import { AIAS } from "../lexicons/aias-base.js";
 
-const AIAS_ORDER = ["FORBJUDET", "TILLATET", "FORVANTAT", "INTEGRERAT"];
+const AIAS_ORDER = ["FORBJUDET", "INTRODUCERA", "FORVANTAT", "INTEGRERAT"];
 
 function getAIAS(subject) {
   const s = String(
@@ -65,8 +65,8 @@ function aiasMark(text, enabled = true, onlyCat = null, aiasLex = AIAS) {
   if (!enabled) return text || "";
   let t = String(text || "");
 
-  const CATEGORY_ORDER = ["INTEGRERAT", "FORVANTAT", "TILLATET", "FORBJUDET"];
-  const ICON_RE = /[⛔✅📌🔗]/;
+  const CATEGORY_ORDER = ["INTEGRERAT", "FORVANTAT", "INTRODUCERA", "FORBJUDET"];
+  const ICON_RE = /[⛔🌱📌🔗]/;
 
   function escapeRegExp(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
   const makeRe = (w) => {
@@ -121,7 +121,7 @@ function buildCategoryRegex(aias) {
 function scoreSentence(sent, rx) {
   const score = {
     FORBJUDET: 0,
-    TILLATET: 0,
+    INTRODUCERA: 0,
     FORVANTAT: 0,
     INTEGRERAT: 0,
   };

--- a/docs/style.css
+++ b/docs/style.css
@@ -184,7 +184,7 @@ button.secondary:hover{background:color-mix(in oklab, var(--accent) 8%, transpar
 
 .sent{display:inline;padding:0 .15em;border-radius:.25rem}
 .sent-forbjudet{background:rgba(220,38,38,.12)}
-.sent-tillatet{background:rgba(234,179,8,.12)}
+.sent-introducera{background:rgba(34,197,94,.12)}
 .sent-forvantat{background:rgba(59,130,246,.12)}
 .sent-integrerat{background:rgba(16,185,129,.12)}
 .sent-neutral{background:transparent}


### PR DESCRIPTION
## Summary
- switch AIAS lexicon category from ✅ Tillåtet to 🌱 Introducera across all lexicon files
- update rendering logic, icon matching, and sentence styling for INTRODUCERA
- refresh docs and footer disclaimer to list the new 🌱 symbol

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b6c10cdc5c83289113e789064d48a2