### PR TITLE
Adjust stage dropdown and central content toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,20 +9,20 @@
 <body>
   <header>
     <div class="row">
-      <div class="row">
-        <label>Ämne</label>
+      <label class="row">
+        <span>Ämne</span>
         <select id="subjectSelect"></select>
-        <span id="subjectSource" class="tiny muted"></span>
-        <span id="lexiconLabel" class="tiny muted"></span>
-      </div>
-      <div class="row">
-        <label>Stadie</label>
+      </label>
+      <span id="subjectSource" class="tiny muted"></span>
+      <span id="lexiconLabel" class="tiny muted"></span>
+      <label class="row">
+        <span>Stadie</span>
         <select id="stageSelect">
-          <option value="1-3">F–3</option>
+          <option value="1-3">1–3</option>
           <option value="4-6" selected>4–6</option>
           <option value="7-9">7–9</option>
         </select>
-      </div>
+      </label>
       <label class="row"><input id="toggleAias" type="checkbox" checked> Visa AI-markeringar (AIAS)</label>
       <label class="row"><input id="toggleCc" type="checkbox"> Markera centralt innehåll</label>
       <span id="status" class="muted"></span>

--- a/docs/index3.html
+++ b/docs/index3.html
@@ -2,7 +2,7 @@
 <html lang="sv">
 <head>
   <meta charset="utf-8" />
-  <title>Syllabus-analys (F–3 / 4–6 / 7–9)</title>
+  <title>Syllabus-analys (1–3 / 4–6 / 7–9)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./style.css" />
 </head>
@@ -10,7 +10,7 @@
   <div class="wrap">
     <header class="top">
       <div>
-        <h1>Syllabus-analys (stadier F–3 / 4–6 / 7–9)</h1>
+        <h1>Syllabus-analys (stadier 1–3 / 4–6 / 7–9)</h1>
         <p class="muted">Ämneslista lokalt → försök hämta detaljer via Skolverkets API, annars fallback till lokalt.</p>
       </div>
       <div class="row">
@@ -64,8 +64,8 @@
             <label>Sortera:
               <select id="ccSort">
                 <option value="">Ursprunglig</option>
-                <option value="asc">F–3 → 7–9</option>
-                <option value="desc">7–9 → F–3</option>
+                <option value="asc">1–3 → 7–9</option>
+                <option value="desc">7–9 → 1–3</option>
               </select>
             </label>
           </div>
@@ -84,7 +84,7 @@
             <label class="tiny">Sortera:
               <select id="assignStageSort">
                 <option value="">Ingen</option>
-                <option value="F-3">F–3</option>
+                <option value="1-3">1–3</option>
                 <option value="4-6">4–6</option>
                 <option value="7-9">7–9</option>
               </select>

--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -176,13 +176,19 @@ function openPromptPreview(promptText) {
     });
   }
   const aiasTgl = $("#toggleAias");
+  const ccTgl = $("#toggleCc");
+  function syncCcToggle() {
+    if (!ccTgl) return;
+    ccTgl.disabled = !aiasTgl?.checked;
+    if (!aiasTgl?.checked) ccTgl.checked = false;
+  }
   if (aiasTgl) {
     aiasTgl.addEventListener("change", () => {
+      syncCcToggle();
       renderText();
       saveLocal();
     });
   }
-  const ccTgl = $("#toggleCc");
   if (ccTgl) {
     ccTgl.addEventListener("change", () => {
       renderText();
@@ -204,6 +210,7 @@ function openPromptPreview(promptText) {
   if (stageSel && prev.stage) stageSel.value = prev.stage;
   if (aiasTgl && typeof prev.aias === "boolean") aiasTgl.checked = prev.aias;
   if (ccTgl && typeof prev.markCC === "boolean") ccTgl.checked = prev.markCC;
+  syncCcToggle();
 
   if (subjSel?.value) {
     await setSubject(subjSel.value, setStatus);


### PR DESCRIPTION
## Summary
- Align stage selector with other controls and rename F–3 option to 1–3
- Replace remaining F–3 references with 1–3 across secondary interface
- Disable “Markera centralt innehåll” checkbox unless AIAS markings are enabled

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check docs/src/app.js`


------
https://chatgpt.com/codex/tasks/task_b_68b6e3b338f08328bcf9588bdc70107f