### PR TITLE
Fix subject dropdown loading error

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -68,7 +68,6 @@ export function buildAiasPrompt({ subject, stage, text, levels }) {
 }
 
 
-}
 
 (function wireExportButtons() {
   const btnDownload = $("#btnDownload");


### PR DESCRIPTION
## Summary
- remove stray brace in `app.js` so module parses and dropdown subjects load

## Testing
- `node --check docs/src/app.js`


------
https://chatgpt.com/codex/tasks/task_b_68b6eef7e0608328a200d5d463c833cd